### PR TITLE
Implemented pending validation support

### DIFF
--- a/user/src/main/java/org/tessell/model/validation/Valid.java
+++ b/user/src/main/java/org/tessell/model/validation/Valid.java
@@ -1,0 +1,17 @@
+package org.tessell.model.validation;
+
+public enum Valid {
+  TRUE, FALSE, PENDING;
+
+  public static Valid fromBoolean(Boolean b) {
+    if (b == null) {
+      return PENDING;
+    } else {
+      if (b) {
+        return TRUE;
+      } else {
+        return FALSE;
+      }
+    }
+  }
+}

--- a/user/src/main/java/org/tessell/model/validation/rules/Custom.java
+++ b/user/src/main/java/org/tessell/model/validation/rules/Custom.java
@@ -1,7 +1,6 @@
 package org.tessell.model.validation.rules;
 
-import static java.lang.Boolean.TRUE;
-
+import org.tessell.model.validation.Valid;
 import org.tessell.util.Supplier;
 
 /** A rule for applying custom logic. */
@@ -16,8 +15,7 @@ public class Custom extends AbstractRule<Object> {
   }
 
   @Override
-  protected boolean isValid() {
-    return TRUE.equals(value.get());
+  protected Valid isValid() {
+    return Valid.fromBoolean(value.get());
   }
-
 }

--- a/user/src/main/java/org/tessell/model/validation/rules/ExternalRule.java
+++ b/user/src/main/java/org/tessell/model/validation/rules/ExternalRule.java
@@ -1,0 +1,17 @@
+package org.tessell.model.validation.rules;
+
+import org.tessell.model.validation.Valid;
+
+public class ExternalRule extends Static {
+
+  public ExternalRule(String message) {
+    super(message);
+  }
+
+  @Override
+  public void triggerIfNeeded(Valid validationResult) {
+    //re-fire triggered event for Valid.PENDING -> Valid.FALSE transition
+    untriggerIfNeeded();
+    super.triggerIfNeeded(validationResult);
+  }
+}

--- a/user/src/main/java/org/tessell/model/validation/rules/Length.java
+++ b/user/src/main/java/org/tessell/model/validation/rules/Length.java
@@ -1,5 +1,7 @@
 package org.tessell.model.validation.rules;
 
+import org.tessell.model.validation.Valid;
+
 /** Validates that a string. */
 public class Length extends AbstractRule<String> {
 
@@ -17,12 +19,12 @@ public class Length extends AbstractRule<String> {
   }
 
   @Override
-  protected boolean isValid() {
+  protected Valid isValid() {
     final String value = property.get();
     if (value == null) {
-      return true; // defer to Required, if it's around
+      return Valid.TRUE; // defer to Required, if it's around
     }
-    return value.length() >= min && value.length() <= max;
+    return Valid.fromBoolean(value.length() >= min && value.length() <= max);
   }
 
 }

--- a/user/src/main/java/org/tessell/model/validation/rules/Range.java
+++ b/user/src/main/java/org/tessell/model/validation/rules/Range.java
@@ -1,5 +1,6 @@
 package org.tessell.model.validation.rules;
 
+import org.tessell.model.validation.Valid;
 
 /** Validates that an int in range. */
 public class Range extends AbstractRule<Integer> {
@@ -14,18 +15,18 @@ public class Range extends AbstractRule<Integer> {
   }
 
   @Override
-  protected boolean isValid() {
+  protected Valid isValid() {
     final Integer value = property.get();
     if (value == null) {
-      return false;
+      return Valid.FALSE;
     }
     if (min != null && value < min) {
-      return false;
+      return Valid.FALSE;
     }
     if (max != null && value > max) {
-      return false;
+      return Valid.FALSE;
     }
-    return true;
+    return Valid.TRUE;
   }
 
 }

--- a/user/src/main/java/org/tessell/model/validation/rules/Regex.java
+++ b/user/src/main/java/org/tessell/model/validation/rules/Regex.java
@@ -1,5 +1,6 @@
 package org.tessell.model.validation.rules;
 
+import org.tessell.model.validation.Valid;
 
 /** Validates that a property matches a regex. */
 public class Regex extends AbstractRule<String> {
@@ -25,12 +26,11 @@ public class Regex extends AbstractRule<String> {
   }
 
   @Override
-  protected boolean isValid() {
+  protected Valid isValid() {
     final String value = property.get();
     if (value == null) {
-      return true; // defer to a Required rule
+      return Valid.TRUE; // defer to a Required rule
     }
-    return value.matches(regex);
+    return Valid.fromBoolean(value.matches(regex));
   }
-
 }

--- a/user/src/main/java/org/tessell/model/validation/rules/Required.java
+++ b/user/src/main/java/org/tessell/model/validation/rules/Required.java
@@ -3,6 +3,7 @@ package org.tessell.model.validation.rules;
 import java.util.List;
 
 import org.tessell.model.properties.Property;
+import org.tessell.model.validation.Valid;
 
 /** Validates that a property is not-null. */
 public class Required extends AbstractRule<Object> {
@@ -25,16 +26,16 @@ public class Required extends AbstractRule<Object> {
   }
 
   @Override
-  protected boolean isValid() {
+  protected Valid isValid() {
     final Object value = property.get();
     if (value instanceof String) {
       // hack to treat empty strings as not entered
-      return (value != null && ((String) value).length() > 0);
+      return Valid.fromBoolean(value != null && ((String) value).length() > 0);
     } else if (value instanceof List) {
       // hack to require lists to be non-empty
-      return (value != null && ((List<?>) value).size() > 0);
+      return Valid.fromBoolean(value != null && ((List<?>) value).size() > 0);
     } else {
-      return value != null;
+      return Valid.fromBoolean(value != null);
     }
   }
 

--- a/user/src/main/java/org/tessell/model/validation/rules/Rule.java
+++ b/user/src/main/java/org/tessell/model/validation/rules/Rule.java
@@ -3,6 +3,7 @@ package org.tessell.model.validation.rules;
 import org.tessell.model.properties.FormattedProperty;
 import org.tessell.model.properties.HasRuleTriggers;
 import org.tessell.model.properties.Property;
+import org.tessell.model.validation.Valid;
 import org.tessell.model.values.Value;
 
 /** A validation rule. */
@@ -12,14 +13,14 @@ public interface Rule<P> extends HasRuleTriggers {
   void setProperty(Property<P> property);
 
   /** @return whether this rule is valid */
-  boolean validate();
+  Valid validate();
 
   /** Ugly hack to put static rule in {@link FormattedProperty} before required rules. */
   boolean isImportant();
 
   void untriggerIfNeeded();
 
-  void triggerIfNeeded();
+  void triggerIfNeeded(Valid validationResult);
 
   void onlyIf(final Value<Boolean> value);
 

--- a/user/src/main/java/org/tessell/model/validation/rules/Size.java
+++ b/user/src/main/java/org/tessell/model/validation/rules/Size.java
@@ -2,6 +2,8 @@ package org.tessell.model.validation.rules;
 
 import java.util.List;
 
+import org.tessell.model.validation.Valid;
+
 public class Size<E> extends AbstractRule<List<E>> {
 
   private final Integer min;
@@ -14,18 +16,18 @@ public class Size<E> extends AbstractRule<List<E>> {
   }
 
   @Override
-  protected boolean isValid() {
+  protected Valid isValid() {
     final Integer value = property.get().size();
     if (value == null) {
-      return false;
+      return Valid.FALSE;
     }
     if (min != null && value < min) {
-      return false;
+      return Valid.FALSE;
     }
     if (max != null && value > max) {
-      return false;
+      return Valid.FALSE;
     }
-    return true;
+    return Valid.TRUE;
   }
 
 }

--- a/user/src/main/java/org/tessell/model/validation/rules/Static.java
+++ b/user/src/main/java/org/tessell/model/validation/rules/Static.java
@@ -1,10 +1,11 @@
 package org.tessell.model.validation.rules;
 
+import org.tessell.model.validation.Valid;
 
 /** A rule that you can explicitly set to valid or invalid as needed. */
 public class Static extends AbstractRule<Object> {
 
-  private boolean valid = true;
+  private Valid valid = Valid.TRUE;
 
   public Static(final String message) {
     super(message);
@@ -12,11 +13,15 @@ public class Static extends AbstractRule<Object> {
 
   // promoted to public access for AbstractRule.clearTemporaryError
   @Override
-  public boolean isValid() {
+  public Valid isValid() {
     return valid;
   }
 
   public void set(final boolean valid) {
+    set(Valid.fromBoolean(valid));
+  }
+
+  public void set(final Valid valid) {
     this.valid = valid;
     if (property != null) {
       property.reassess();

--- a/user/src/main/java/org/tessell/model/validation/rules/Transient.java
+++ b/user/src/main/java/org/tessell/model/validation/rules/Transient.java
@@ -3,6 +3,7 @@ package org.tessell.model.validation.rules;
 import org.tessell.model.events.PropertyChangedEvent;
 import org.tessell.model.events.PropertyChangedHandler;
 import org.tessell.model.properties.Property;
+import org.tessell.model.validation.Valid;
 
 /** A rule that fires immediately, until the source property changes. */
 public class Transient<T> extends AbstractRule<T> {
@@ -26,8 +27,8 @@ public class Transient<T> extends AbstractRule<T> {
   }
 
   @Override
-  protected boolean isValid() {
-    return hasChanged;
+  protected Valid isValid() {
+    return Valid.fromBoolean(hasChanged);
   }
 
 }

--- a/user/src/test/java/org/tessell/tests/model/properties/ListPropertyTest.java
+++ b/user/src/test/java/org/tessell/tests/model/properties/ListPropertyTest.java
@@ -25,6 +25,7 @@ import org.tessell.model.properties.*;
 import org.tessell.model.properties.ListProperty.ElementConverter;
 import org.tessell.model.properties.ListProperty.ElementFilter;
 import org.tessell.model.properties.ListProperty.ElementMapper;
+import org.tessell.model.validation.Valid;
 import org.tessell.model.validation.rules.AbstractRule;
 import org.tessell.model.validation.rules.Size;
 import org.tessell.model.values.DerivedValue;
@@ -1140,8 +1141,8 @@ public class ListPropertyTest {
     assertThat(l.allValid().get(), is(true));
 
     l.addRule(new AbstractRule<List<StringProperty>>("Only one allowed") {
-      protected boolean isValid() {
-        return property.get().size() == 1;
+      protected Valid isValid() {
+        return Valid.fromBoolean(property.get().size() == 1);
       }
     });
     assertThat(l.allValid().get(), is(false));
@@ -1168,8 +1169,8 @@ public class ListPropertyTest {
     assertThat(l.allValid().get(), is(true));
 
     l.addRule(new AbstractRule<List<DummyModel>>("Only one allowed") {
-      protected boolean isValid() {
-        return property.get().size() == 1;
+      protected Valid isValid() {
+        return Valid.fromBoolean(property.get().size() == 1);
       }
     });
     assertThat(l.allValid().get(), is(false));

--- a/user/src/test/java/org/tessell/tests/model/validation/rules/RulesTest.java
+++ b/user/src/test/java/org/tessell/tests/model/validation/rules/RulesTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.tessell.model.properties.BooleanProperty;
 import org.tessell.model.properties.StringProperty;
+import org.tessell.model.validation.Valid;
 import org.tessell.model.validation.events.RuleTriggeredEvent;
 import org.tessell.model.validation.events.RuleTriggeredHandler;
 import org.tessell.model.validation.rules.Custom;
@@ -115,8 +116,8 @@ public class RulesTest extends AbstractRuleTest {
   @Test
   public void requiredSubclassWillBeTrackUpstreamValues() {
     f.name.addRule(new Required("Required") {
-      protected boolean isValid() {
-        return f.description.get() != null;
+      protected Valid isValid() {
+        return Valid.fromBoolean(f.description.get() != null);
       }
     });
 


### PR DESCRIPTION
These are the changes we had talked about using for validating that we have access to a company page on the server side (although we may not wind up doing that).

Adding the "ExternalRule" class is a little bit of a hack.  I realized late that (without it) a rule that went from Valid.PENDING to Valid.FALSE would not re-trigger the event (because it was already flagged as triggered), so the validation message would not be shown.  (The way my initial test was structured hid this bug.)  As a result, pending validation won't work for any of the other concrete rule types.  A better approach might be for AbstractRule to know about the previous validation result (so it can untrigger before re-triggering if the validation result changed), although I'm not sure if that's fool-proof.  In any case, I'd like to at least get some feedback and not let these changes linger in purgatory on my machine.
