### PR TITLE
Addressed issue with generated ClientResoures @Source annotation valu…

### DIFF
--- a/dev/src/main/java/org/tessell/generators/resources/ResourcesGenerator.java
+++ b/dev/src/main/java/org/tessell/generators/resources/ResourcesGenerator.java
@@ -211,14 +211,24 @@ public class ResourcesGenerator {
   }
 
   private String getRelativePath(File file) {
-    String path = file.getAbsolutePath();
+    String path = absolutePath(file);
+    String inputDirectoryPath = absolutePath(inputDirectory);
     String relativePath;
-    if (path.contains(inputDirectory.getAbsolutePath())) {
-      relativePath = path.replace(inputDirectory.getAbsolutePath() + "/" + packageName.replace(".", "/") + "/", "");
+    if (path.contains(inputDirectoryPath)) {
+      relativePath = path.replace(inputDirectoryPath + "/" + packageName.replace(".", "/") + "/", "");
     } else {
-      relativePath = path.replace(outputDirectory.getAbsolutePath() + "/" + packageName.replace(".", "/") + "/", "");
+      String outputDirectoryPath = absolutePath(outputDirectory);
+      relativePath = path.replace(outputDirectoryPath + "/" + packageName.replace(".", "/") + "/", "");
     }
-    return relativePath.replace("\\", "/");
+    return relativePath;
+  }
+
+  private String absolutePath(File file) {
+    return slashSanitise(file.getAbsolutePath());
+  }
+
+  private String slashSanitise(String value) {
+    return value.replaceAll("\\\\", "/");
   }
 
   private Collection<File> getFilesInInputDirectory() {


### PR DESCRIPTION
…e reflecting the absolute path rather than just the resource file name on the Windows platform.

This occurs when the slashes on the input / output directories do not match those on the resolved resource file.

Or to put is more succinctly - Because Windows.